### PR TITLE
chore(deps): modernise SDK constraints and lints (#3)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,22 @@
 include: package:flutter_lints/flutter.yaml
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+  errors:
+    missing_return: error
+    dead_code: warning
+
+linter:
+  rules:
+    - always_declare_return_types
+    - prefer_const_constructors
+    - prefer_const_declarations
+    - prefer_single_quotes
+    - use_super_parameters
+    - avoid_print
+    - prefer_final_locals
+    - sort_constructors_first
+    - unawaited_futures

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,9 +51,7 @@ class _MyAppState extends State<MyApp> {
                         color: Colors.blue,
                         width: 1500,
                         height: 1500,
-                        child: Center(
-                            child: Text(
-                                List.filled(1400, 'hello world').join(' ')))),
+                        child: Center(child: Text(List.filled(1400, 'hello world').join(' ')))),
                   ),
                 ),
               ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,34 +21,34 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -58,10 +58,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "5.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -71,78 +71,78 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "5.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   single_child_two_dimensional_scroll_view:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -155,18 +155,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -187,18 +187,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -208,5 +208,5 @@ packages:
     source: hosted
     version: "14.2.1"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0-0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^5.0.0
 
 flutter:
   uses-material-design: true

--- a/lib/single_child_two_dimensional_scroll_view.dart
+++ b/lib/single_child_two_dimensional_scroll_view.dart
@@ -189,8 +189,7 @@ class SingleChildTwoDimensionalScrollView extends StatelessWidget {
         controller: horizontalController,
         decorationClipBehavior: clipBehavior,
       ),
-      delegate:
-          TwoDimensionalChildBuilderDelegate(builder: (_, __) => contents),
+      delegate: TwoDimensionalChildBuilderDelegate(builder: (_, __) => contents),
       primary: primary,
       keyboardDismissBehavior: keyboardDismissBehavior,
       clipBehavior: clipBehavior,
@@ -203,12 +202,12 @@ class _SingleChild2DScrollView extends TwoDimensionalScrollView {
   const _SingleChild2DScrollView({
     required super.verticalDetails,
     required super.horizontalDetails,
-    required TwoDimensionalChildDelegate delegate,
+    required super.delegate,
     super.primary,
     super.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     super.clipBehavior = Clip.hardEdge,
     super.diagonalDragBehavior,
-  }) : super(delegate: delegate);
+  });
 
   @override
   Widget buildViewport(
@@ -257,8 +256,8 @@ class _SingleChild2DViewPort extends TwoDimensionalViewport {
   }
 
   @override
-  void updateRenderObject(BuildContext context,
-      covariant _RenderSingleChild2DViewPort renderObject) {
+  void updateRenderObject(
+      BuildContext context, covariant _RenderSingleChild2DViewPort renderObject) {
     renderObject
       ..horizontalOffset = horizontalOffset
       ..horizontalAxisDirection = horizontalAxisDirection
@@ -304,8 +303,7 @@ class _RenderSingleChild2DViewPort extends RenderTwoDimensionalViewport {
         0, clampDouble(child.size.height - viewportHeight, 0, double.infinity));
   }
 
-  final LayerHandle<ClipRectLayer> _clipRectLayer =
-      LayerHandle<ClipRectLayer>();
+  final LayerHandle<ClipRectLayer> _clipRectLayer = LayerHandle<ClipRectLayer>();
 
   @override
   void dispose() {
@@ -335,7 +333,7 @@ class _RenderSingleChild2DViewPort extends RenderTwoDimensionalViewport {
     if (child == null) return;
     final paintOffset = parentDataOf(child).paintOffset!;
 
-    void paintChild(context, offset) {
+    void paintChild(PaintingContext context, Offset offset) {
       context.paintChild(child, offset + paintOffset);
     }
 
@@ -378,10 +376,8 @@ class _RenderSingleChild2DViewPort extends RenderTwoDimensionalViewport {
       curve: curve,
     );
     if (newRect == null && descendant is RenderBox) {
-      double offsetX =
-          getOffsetToReveal(descendant, 0.0, axis: Axis.horizontal).offset;
-      double offsetY =
-          getOffsetToReveal(descendant, 0.0, axis: Axis.vertical).offset;
+      final double offsetX = getOffsetToReveal(descendant, 0.0, axis: Axis.horizontal).offset;
+      final double offsetY = getOffsetToReveal(descendant, 0.0, axis: Axis.vertical).offset;
       if (offsetX == 0 && offsetY == 0) {
         newRect = Offset.zero & descendant.size;
       }
@@ -406,15 +402,15 @@ class _RenderSingleChild2DViewPort extends RenderTwoDimensionalViewport {
 
   @override
   Rect? describeSemanticsClip(RenderObject child) {
-    double maxScrollXExtent = clampDouble(
-        firstChild!.size.width - viewportDimension.width, 0, double.infinity);
-    double maxScrollYExtent = clampDouble(
-        firstChild!.size.height - viewportDimension.height, 0, double.infinity);
+    final double maxScrollXExtent =
+        clampDouble(firstChild!.size.width - viewportDimension.width, 0, double.infinity);
+    final double maxScrollYExtent =
+        clampDouble(firstChild!.size.height - viewportDimension.height, 0, double.infinity);
 
     final double remainingOffsetX = maxScrollXExtent - horizontalOffset.pixels;
     final double remainingOffsetY = maxScrollYExtent - verticalOffset.pixels;
 
-    Rect rect = Rect.fromLTRB(
+    final Rect rect = Rect.fromLTRB(
       semanticBounds.left - horizontalOffset.pixels,
       semanticBounds.top - verticalOffset.pixels,
       semanticBounds.right + remainingOffsetX,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.3
 homepage: https://github.com/sjhorn/single_child_two_dimensional_scroll_view/tree/main
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
-  flutter: ">=1.17.0"
+  sdk: '>=3.6.0 <4.0.0'
+  flutter: ">=3.27.0"
 
 dependencies:
   flutter:
@@ -14,6 +14,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^5.0.0
 
 flutter:

--- a/scripts/ci/ci_gate.sh
+++ b/scripts/ci/ci_gate.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# scripts/ci/ci_gate.sh
+#
+# Run the full commit gate: analyze -> format check -> test.
+# Each sub-script captures its own verbose output to /tmp log files
+# and prints only a summary to stdout.
+#
+# Usage:
+#   ./scripts/ci/ci_gate.sh                  # full gate, summary only
+#   ./scripts/ci/ci_gate.sh --fix            # auto-fix format + lint before checking
+#   ./scripts/ci/ci_gate.sh --verbose        # full gate, verbose output
+#   ./scripts/ci/ci_gate.sh test/src/model/  # gate scoped to one layer
+#
+# Output files written:
+#   /tmp/${PREFIX}_gate_summary.txt — pass/fail per step + overall result
+#   (plus each sub-script's own /tmp/${PREFIX}_*.txt files)
+
+set -uo pipefail
+exec 2>&1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+
+VERBOSE=false
+FIX=false
+ARGS=()
+for arg in "$@"; do
+  if [ "$arg" = "--verbose" ]; then
+    VERBOSE=true
+  elif [ "$arg" = "--fix" ]; then
+    FIX=true
+  else
+    ARGS+=("$arg")
+  fi
+done
+
+SUMMARYFILE="/tmp/${PREFIX}_gate_summary.txt"
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+SCOPE="${ARGS[0]:-}"
+
+VERBOSE_FLAG=""
+if [ "$VERBOSE" = true ]; then
+  VERBOSE_FLAG="--verbose"
+fi
+
+# Step 0 (optional): auto-fix format + lint
+if [ "$FIX" = true ]; then
+  echo ">>> dart fix apply"
+  "$SCRIPT_DIR/dart_fix.sh" apply $VERBOSE_FLAG ${SCOPE:+"$SCOPE"} || true
+  echo ""
+  echo ">>> dart format fix"
+  "$SCRIPT_DIR/dart_format.sh" fix $VERBOSE_FLAG ${SCOPE:+"$SCOPE"} || true
+  echo ""
+fi
+
+RESULT_ANALYZE="SKIP"
+RESULT_FORMAT="SKIP"
+RESULT_TEST="SKIP"
+RESULT_COVERAGE="SKIP"
+RESULT_DARTDOC="SKIP"
+RESULT_EXAMPLE="SKIP"
+
+# Resolve project root (two levels above scripts/ci/).
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Step 1: analyze
+echo ">>> flutter analyze"
+if "$SCRIPT_DIR/flutter_analyze.sh" $VERBOSE_FLAG ${SCOPE:+"$SCOPE"}; then
+  RESULT_ANALYZE="PASS"
+else
+  RESULT_ANALYZE="FAIL"
+fi
+echo ""
+
+# Step 2: format check
+echo ">>> dart format check"
+if "$SCRIPT_DIR/dart_format.sh" check $VERBOSE_FLAG ${SCOPE:+"$SCOPE"}; then
+  RESULT_FORMAT="PASS"
+else
+  RESULT_FORMAT="FAIL"
+fi
+echo ""
+
+# Step 3: tests
+echo ">>> flutter test"
+if "$SCRIPT_DIR/flutter_test.sh" $VERBOSE_FLAG ${SCOPE:+"$SCOPE"}; then
+  RESULT_TEST="PASS"
+else
+  RESULT_TEST="FAIL"
+fi
+echo ""
+
+# Step 4: coverage (90% threshold, skip for scoped runs)
+if [ -z "$SCOPE" ]; then
+  echo ">>> coverage"
+  if "$SCRIPT_DIR/coverage.sh" $VERBOSE_FLAG; then
+    RESULT_COVERAGE="PASS"
+  else
+    RESULT_COVERAGE="FAIL"
+  fi
+  echo ""
+fi
+
+# Step 5: dartdoc validation (skip for scoped runs)
+if [ -z "$SCOPE" ]; then
+  echo ">>> dart doc"
+  DARTDOC_LOG="/tmp/${PREFIX}_dartdoc_full.txt"
+  if dart doc --validate-links >"$DARTDOC_LOG" 2>&1; then
+    RESULT_DARTDOC="PASS"
+  else
+    RESULT_DARTDOC="FAIL"
+  fi
+  DARTDOC_WARNINGS=$(grep -c "warning" "$DARTDOC_LOG" 2>/dev/null || echo "0")
+  echo "  Warnings: $DARTDOC_WARNINGS"
+  echo ""
+fi
+
+# Step 6: example app gate
+EXAMPLE_DIR="$PROJECT_ROOT/example"
+if [ -z "$SCOPE" ] && [ -f "$EXAMPLE_DIR/pubspec.yaml" ]; then
+  echo ">>> example: flutter pub get + analyze + format"
+  if (cd "$EXAMPLE_DIR" && flutter pub get --no-example && flutter analyze lib/ && dart format --line-length 100 --set-exit-if-changed lib/); then
+    RESULT_EXAMPLE="PASS"
+  else
+    RESULT_EXAMPLE="FAIL"
+  fi
+  echo ""
+fi
+
+# Determine overall result
+OVERALL="PASS"
+if [ "$RESULT_ANALYZE" = "FAIL" ] || [ "$RESULT_FORMAT" = "FAIL" ] || [ "$RESULT_TEST" = "FAIL" ] || [ "$RESULT_COVERAGE" = "FAIL" ] || [ "$RESULT_DARTDOC" = "FAIL" ] || [ "$RESULT_EXAMPLE" = "FAIL" ]; then
+  OVERALL="FAIL"
+fi
+
+{
+  echo "=== CI gate summary ==="
+  echo "Timestamp : $TIMESTAMP"
+  echo "Scope     : ${SCOPE:-all}"
+  echo "Fix       : $FIX"
+  echo ""
+  echo "  flutter analyze   : $RESULT_ANALYZE"
+  echo "  dart format check : $RESULT_FORMAT"
+  echo "  flutter test      : $RESULT_TEST"
+  echo "  coverage (≥90%)   : $RESULT_COVERAGE"
+  echo "  dart doc          : $RESULT_DARTDOC"
+  echo "  example gate      : $RESULT_EXAMPLE"
+  echo ""
+  echo "Overall   : $OVERALL"
+} | tee "$SUMMARYFILE"
+
+[ "$OVERALL" = "PASS" ] && exit 0 || exit 1

--- a/test/rendering_tester.dart
+++ b/test/rendering_tester.dart
@@ -14,8 +14,7 @@ import 'package:flutter_test/flutter_test.dart'
     show EnginePhase, TestDefaultBinaryMessengerBinding, fail;
 
 export 'package:flutter/foundation.dart' show FlutterError, FlutterErrorDetails;
-export 'package:flutter_test/flutter_test.dart'
-    show EnginePhase, TestDefaultBinaryMessengerBinding;
+export 'package:flutter_test/flutter_test.dart' show EnginePhase, TestDefaultBinaryMessengerBinding;
 
 class TestRenderingFlutterBinding extends BindingBase
     with
@@ -38,8 +37,7 @@ class TestRenderingFlutterBinding extends BindingBase
   TestRenderingFlutterBinding({this.onErrors}) {
     FlutterError.onError = (FlutterErrorDetails details) {
       FlutterError.dumpErrorToConsole(details);
-      Zone.current.parent!
-          .handleUncaughtError(details.exception, details.stack!);
+      Zone.current.parent!.handleUncaughtError(details.exception, details.stack!);
     };
   }
 
@@ -48,8 +46,7 @@ class TestRenderingFlutterBinding extends BindingBase
   /// Provides access to the features exposed by this binding. The binding must
   /// be initialized before using this getter; this is typically done by calling
   /// [TestRenderingFlutterBinding.ensureInitialized].
-  static TestRenderingFlutterBinding get instance =>
-      BindingBase.checkInstance(_instance);
+  static TestRenderingFlutterBinding get instance => BindingBase.checkInstance(_instance);
   static TestRenderingFlutterBinding? _instance;
 
   @override
@@ -99,8 +96,7 @@ class TestRenderingFlutterBinding extends BindingBase
   /// Creates and initializes the binding. This function is
   /// idempotent; calling it a second time will just return the
   /// previously-created instance.
-  static TestRenderingFlutterBinding ensureInitialized(
-      {VoidCallback? onErrors}) {
+  static TestRenderingFlutterBinding ensureInitialized({VoidCallback? onErrors}) {
     if (_instance != null) {
       return _instance!;
     }
@@ -180,8 +176,7 @@ class TestRenderingFlutterBinding extends BindingBase
           }
         } else {
           _errors.forEach(FlutterError.dumpErrorToConsole);
-          fail(
-              'Caught error while rendering frame. See preceding logs for details.');
+          fail('Caught error while rendering frame. See preceding logs for details.');
         }
       }
     }
@@ -216,8 +211,7 @@ class TestRenderingFlutterBinding extends BindingBase
       if (phase == EnginePhase.flushSemantics) {
         return;
       }
-      assert(phase == EnginePhase.flushSemantics ||
-          phase == EnginePhase.sendSemanticsUpdate);
+      assert(phase == EnginePhase.flushSemantics || phase == EnginePhase.sendSemanticsUpdate);
     } finally {
       FlutterError.onError = oldErrorHandler;
       if (_errors.isNotEmpty) {
@@ -230,8 +224,7 @@ class TestRenderingFlutterBinding extends BindingBase
           }
         } else {
           _errors.forEach(FlutterError.dumpErrorToConsole);
-          fail(
-              'Caught error while rendering frame. See preceding logs for details.');
+          fail('Caught error while rendering frame. See preceding logs for details.');
         }
       }
     }
@@ -260,8 +253,7 @@ void layout(
   EnginePhase phase = EnginePhase.layout,
   VoidCallback? onErrors,
 }) {
-  assert(box.parent ==
-      null); // We stick the box in another, so you can't reuse it easily, sorry.
+  assert(box.parent == null); // We stick the box in another, so you can't reuse it easily, sorry.
 
   TestRenderingFlutterBinding.instance.renderView.child = null;
   if (constraints != null) {
@@ -281,10 +273,8 @@ void layout(
 /// Pumps a single frame.
 ///
 /// If `onErrors` is not null, it is set as [TestRenderingFlutterBinding.onError].
-void pumpFrame(
-    {EnginePhase phase = EnginePhase.layout, VoidCallback? onErrors}) {
-  assert(TestRenderingFlutterBinding.instance.renderView.child !=
-      null); // call layout() first!
+void pumpFrame({EnginePhase phase = EnginePhase.layout, VoidCallback? onErrors}) {
+  assert(TestRenderingFlutterBinding.instance.renderView.child != null); // call layout() first!
 
   if (onErrors != null) {
     TestRenderingFlutterBinding.instance.onErrors = onErrors;
@@ -360,6 +350,9 @@ class FakeTicker implements Ticker {
   bool muted = false;
 
   @override
+  bool forceFrames = false;
+
+  @override
   void absorbTicker(Ticker originalTicker) {}
 
   @override
@@ -399,16 +392,14 @@ class FakeTicker implements Ticker {
 
   @override
   DiagnosticsNode describeForError(String name) {
-    return DiagnosticsProperty<Ticker>(name, this,
-        style: DiagnosticsTreeStyle.errorProperty);
+    return DiagnosticsProperty<Ticker>(name, this, style: DiagnosticsTreeStyle.errorProperty);
   }
 }
 
 class TestClipPaintingContext extends PaintingContext {
   TestClipPaintingContext() : this._(ContainerLayer());
 
-  TestClipPaintingContext._(this._containerLayer)
-      : super(_containerLayer, Rect.zero);
+  TestClipPaintingContext._(this._containerLayer) : super(_containerLayer, Rect.zero);
 
   final ContainerLayer _containerLayer;
 
@@ -439,12 +430,10 @@ class TestPushLayerPaintingContext extends PaintingContext {
   final List<ContainerLayer> pushedLayers = <ContainerLayer>[];
 
   @override
-  void pushLayer(
-      ContainerLayer childLayer, PaintingContextCallback painter, Offset offset,
+  void pushLayer(ContainerLayer childLayer, PaintingContextCallback painter, Offset offset,
       {Rect? childPaintBounds}) {
     pushedLayers.add(childLayer);
-    super.pushLayer(childLayer, painter, offset,
-        childPaintBounds: childPaintBounds);
+    super.pushLayer(childLayer, painter, offset, childPaintBounds: childPaintBounds);
   }
 }
 
@@ -452,8 +441,7 @@ class TestPushLayerPaintingContext extends PaintingContext {
 void absorbOverflowedErrors() {
   final Iterable<FlutterErrorDetails> errorDetails =
       TestRenderingFlutterBinding.instance.takeAllFlutterErrorDetails();
-  final Iterable<FlutterErrorDetails> filtered =
-      errorDetails.where((FlutterErrorDetails details) {
+  final Iterable<FlutterErrorDetails> filtered = errorDetails.where((FlutterErrorDetails details) {
     return !details.toString().contains('overflowed');
   });
   if (filtered.isNotEmpty) {
@@ -469,5 +457,4 @@ void expectNoFlutterErrors() {
 }
 
 RenderConstrainedBox get box200x200 => RenderConstrainedBox(
-    additionalConstraints:
-        const BoxConstraints.tightFor(height: 200.0, width: 200.0));
+    additionalConstraints: const BoxConstraints.tightFor(height: 200.0, width: 200.0));

--- a/test/semantics_tester.dart
+++ b/test/semantics_tester.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show CheckedState, SemanticsFlags, Tristate;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
@@ -45,8 +47,6 @@ class TestSemantics {
     this.textDirection,
     this.rect,
     this.transform,
-    this.elevation,
-    this.thickness,
     this.textSelection,
     this.children = const <TestSemantics>[],
     this.scrollIndex,
@@ -78,8 +78,6 @@ class TestSemantics {
         assert(flags is int || flags is List<SemanticsFlag>),
         assert(actions is int || actions is List<SemanticsAction>),
         rect = TestSemantics.rootRect,
-        elevation = 0.0,
-        thickness = 0.0,
         tags = tags?.toSet() ?? <SemanticsTag>{};
 
   /// Creates an object with some test semantics data, with the [id] and [rect]
@@ -105,8 +103,6 @@ class TestSemantics {
     this.textDirection,
     this.rect,
     Matrix4? transform,
-    this.elevation,
-    this.thickness,
     this.textSelection,
     this.children = const <TestSemantics>[],
     this.scrollIndex,
@@ -201,21 +197,6 @@ class TestSemantics {
   /// parent).
   final Matrix4? transform;
 
-  /// The elevation of this node relative to the parent node.
-  ///
-  /// See also:
-  ///
-  ///  * [SemanticsConfiguration.elevation] for a detailed discussion regarding
-  ///    elevation and semantics.
-  final double? elevation;
-
-  /// The extend that this node occupies in z-direction starting at [elevation].
-  ///
-  /// See also:
-  ///
-  ///  * [SemanticsConfiguration.thickness] for a more detailed definition.
-  final double? thickness;
-
   /// The index of the first visible semantic node within a scrollable.
   final int? scrollIndex;
 
@@ -262,17 +243,17 @@ class TestSemantics {
 
     final int flagsBitmask = flags is int
         ? flags as int
-        : (flags as List<SemanticsFlag>).fold<int>(
-            0, (int bitmask, SemanticsFlag flag) => bitmask | flag.index);
-    if (flagsBitmask != nodeData.flags) {
-      return fail(
-          'expected node id $id to have flags $flags but found flags ${nodeData.flags}.');
+        : (flags as List<SemanticsFlag>)
+            .fold<int>(0, (int bitmask, SemanticsFlag flag) => bitmask | flag.index);
+    final int actualFlagsBitmask = _semFlagsToBitMask(nodeData.flagsCollection);
+    if (flagsBitmask != actualFlagsBitmask) {
+      return fail('expected node id $id to have flags $flags but found flags $actualFlagsBitmask.');
     }
 
     final int actionsBitmask = actions is int
         ? actions as int
-        : (actions as List<SemanticsAction>).fold<int>(
-            0, (int bitmask, SemanticsAction action) => bitmask | action.index);
+        : (actions as List<SemanticsAction>)
+            .fold<int>(0, (int bitmask, SemanticsAction action) => bitmask | action.index);
     if (actionsBitmask != nodeData.actions) {
       return fail(
           'expected node id $id to have actions $actions but found actions ${nodeData.actions}.');
@@ -295,8 +276,7 @@ class TestSemantics {
           'expected node id $id to have decreasedValue "$decreasedValue" but found value "${nodeData.decreasedValue}".');
     }
     if (hint != nodeData.hint) {
-      return fail(
-          'expected node id $id to have hint "$hint" but found hint "${nodeData.hint}".');
+      return fail('expected node id $id to have hint "$hint" but found hint "${nodeData.hint}".');
     }
     if (tooltip != nodeData.tooltip) {
       return fail(
@@ -316,20 +296,11 @@ class TestSemantics {
           'expected node id $id, which has a label, value, or hint, to have a textDirection, but it did not.');
     }
     if (!ignoreRect && rect != nodeData.rect) {
-      return fail(
-          'expected node id $id to have rect $rect but found rect ${nodeData.rect}.');
+      return fail('expected node id $id to have rect $rect but found rect ${nodeData.rect}.');
     }
     if (!ignoreTransform && transform != nodeData.transform) {
       return fail(
           'expected node id $id to have transform $transform but found transform:\n${nodeData.transform}.');
-    }
-    if (elevation != null && elevation != nodeData.elevation) {
-      return fail(
-          'expected node id $id to have elevation $elevation but found elevation:\n${nodeData.elevation}.');
-    }
-    if (thickness != null && thickness != nodeData.thickness) {
-      return fail(
-          'expected node id $id to have thickness $thickness but found thickness:\n${nodeData.thickness}.');
     }
     if (textSelection?.baseOffset != nodeData.textSelection?.baseOffset ||
         textSelection?.extentOffset != nodeData.textSelection?.extentOffset) {
@@ -344,8 +315,7 @@ class TestSemantics {
       return fail(
           'expected node id $id to have scrollIndex $scrollChildren but found scrollIndex ${nodeData.scrollChildCount}.');
     }
-    final int childrenCount =
-        node.mergeAllDescendantsIntoThisNode ? 0 : node.childrenCount;
+    final int childrenCount = node.mergeAllDescendantsIntoThisNode ? 0 : node.childrenCount;
     if (children.length != childrenCount) {
       return fail(
           'expected node id $id to have ${children.length} child${children.length == 1 ? "" : "ren"} but found $childrenCount.');
@@ -356,8 +326,7 @@ class TestSemantics {
     }
     bool result = true;
     final Iterator<TestSemantics> it = children.iterator;
-    for (final SemanticsNode child
-        in node.debugListChildrenInOrder(childOrder)) {
+    for (final SemanticsNode child in node.debugListChildrenInOrder(childOrder)) {
       it.moveNext();
       final bool childMatches = it.current._matches(
         child,
@@ -387,14 +356,11 @@ class TestSemantics {
       buf.writeln('$indent  id: $id,');
     }
     if (flags is int && flags != 0 ||
-        flags is List<SemanticsFlag> &&
-            (flags as List<SemanticsFlag>).isNotEmpty) {
-      buf.writeln(
-          '$indent  flags: ${SemanticsTester._flagsToSemanticsFlagExpression(flags)},');
+        flags is List<SemanticsFlag> && (flags as List<SemanticsFlag>).isNotEmpty) {
+      buf.writeln('$indent  flags: ${SemanticsTester._flagsToSemanticsFlagExpression(flags)},');
     }
     if (actions is int && actions != 0 ||
-        actions is List<SemanticsAction> &&
-            (actions as List<SemanticsAction>).isNotEmpty) {
+        actions is List<SemanticsAction> && (actions as List<SemanticsAction>).isNotEmpty) {
       buf.writeln(
           '$indent  actions: ${SemanticsTester._actionsToSemanticsActionExpression(actions)},');
     }
@@ -420,8 +386,7 @@ class TestSemantics {
       buf.writeln('$indent  textDirection: $textDirection,');
     }
     if (textSelection?.isValid ?? false) {
-      buf.writeln(
-          '$indent  textSelection:\n[${textSelection!.start}, ${textSelection!.end}],');
+      buf.writeln('$indent  textSelection:\n[${textSelection!.start}, ${textSelection!.end}],');
     }
     if (scrollIndex != null) {
       buf.writeln('$indent scrollIndex: $scrollIndex,');
@@ -432,12 +397,6 @@ class TestSemantics {
     if (transform != null) {
       buf.writeln(
           '$indent  transform:\n${transform.toString().trim().split('\n').map<String>((String line) => '$indent    $line').join('\n')},');
-    }
-    if (elevation != null) {
-      buf.writeln('$indent  elevation: $elevation,');
-    }
-    if (thickness != null) {
-      buf.writeln('$indent  thickness: $thickness,');
     }
     buf.writeln('$indent  children: <TestSemantics>[');
     for (final TestSemantics child in children) {
@@ -486,17 +445,15 @@ class SemanticsTester {
 
   @override
   String toString() =>
-      'SemanticsTester for ${tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode}';
+      'SemanticsTester for ${_findRootSemanticsNode(tester.binding.rootPipelineOwner)}';
 
-  bool _stringAttributesEqual(
-      List<StringAttribute> first, List<StringAttribute> second) {
+  bool _stringAttributesEqual(List<StringAttribute> first, List<StringAttribute> second) {
     if (first.length != second.length) {
       return false;
     }
     for (int i = 0; i < first.length; i++) {
       if (first[i] is SpellOutStringAttribute &&
-          (second[i] is! SpellOutStringAttribute ||
-              second[i].range != first[i].range)) {
+          (second[i] is! SpellOutStringAttribute || second[i].range != first[i].range)) {
         return false;
       }
       if (first[i] is LocaleStringAttribute &&
@@ -541,8 +498,8 @@ class SemanticsTester {
       }
       if (attributedLabel != null &&
           (attributedLabel.string != node.attributedLabel.string ||
-              !_stringAttributesEqual(attributedLabel.attributes,
-                  node.attributedLabel.attributes))) {
+              !_stringAttributesEqual(
+                  attributedLabel.attributes, node.attributedLabel.attributes))) {
         return false;
       }
       if (value != null && node.value != value) {
@@ -550,8 +507,8 @@ class SemanticsTester {
       }
       if (attributedValue != null &&
           (attributedValue.string != node.attributedValue.string ||
-              !_stringAttributesEqual(attributedValue.attributes,
-                  node.attributedValue.attributes))) {
+              !_stringAttributesEqual(
+                  attributedValue.attributes, node.attributedValue.attributes))) {
         return false;
       }
       if (hint != null && node.hint != hint) {
@@ -559,25 +516,24 @@ class SemanticsTester {
       }
       if (attributedHint != null &&
           (attributedHint.string != node.attributedHint.string ||
-              !_stringAttributesEqual(
-                  attributedHint.attributes, node.attributedHint.attributes))) {
+              !_stringAttributesEqual(attributedHint.attributes, node.attributedHint.attributes))) {
         return false;
       }
       if (textDirection != null && node.textDirection != textDirection) {
         return false;
       }
       if (actions != null) {
-        final int expectedActions = actions.fold<int>(
-            0, (int value, SemanticsAction action) => value | action.index);
+        final int expectedActions =
+            actions.fold<int>(0, (int value, SemanticsAction action) => value | action.index);
         final int actualActions = node.getSemanticsData().actions;
         if (expectedActions != actualActions) {
           return false;
         }
       }
       if (flags != null) {
-        final int expectedFlags = flags.fold<int>(
-            0, (int value, SemanticsFlag flag) => value | flag.index);
-        final int actualFlags = node.getSemanticsData().flags;
+        final int expectedFlags =
+            flags.fold<int>(0, (int value, SemanticsFlag flag) => value | flag.index);
+        final int actualFlags = _semFlagsToBitMask(node.getSemanticsData().flagsCollection);
         if (expectedFlags != actualFlags) {
           return false;
         }
@@ -588,20 +544,16 @@ class SemanticsTester {
           return false;
         }
       }
-      if (scrollPosition != null &&
-          !nearEqual(node.scrollPosition, scrollPosition, 0.1)) {
+      if (scrollPosition != null && !nearEqual(node.scrollPosition, scrollPosition, 0.1)) {
         return false;
       }
-      if (scrollExtentMax != null &&
-          !nearEqual(node.scrollExtentMax, scrollExtentMax, 0.1)) {
+      if (scrollExtentMax != null && !nearEqual(node.scrollExtentMax, scrollExtentMax, 0.1)) {
         return false;
       }
-      if (scrollExtentMin != null &&
-          !nearEqual(node.scrollExtentMin, scrollExtentMin, 0.1)) {
+      if (scrollExtentMin != null && !nearEqual(node.scrollExtentMin, scrollExtentMin, 0.1)) {
         return false;
       }
-      if (currentValueLength != null &&
-          node.currentValueLength != currentValueLength) {
+      if (currentValueLength != null && node.currentValueLength != currentValueLength) {
         return false;
       }
       if (maxValueLength != null && node.maxValueLength != maxValueLength) {
@@ -622,7 +574,7 @@ class SemanticsTester {
     if (ancestor != null) {
       visit(ancestor);
     } else {
-      visit(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
+      visit(_findRootSemanticsNode(tester.binding.rootPipelineOwner)!);
     }
     return result;
   }
@@ -677,16 +629,14 @@ class SemanticsTester {
   /// individually.
   String generateTestSemanticsExpressionForCurrentSemanticsTree(
       DebugSemanticsDumpOrder childOrder) {
-    final SemanticsNode? node =
-        tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode;
+    final SemanticsNode? node = _findRootSemanticsNode(tester.binding.rootPipelineOwner);
     return _generateSemanticsTestForNode(node, 0, childOrder);
   }
 
   static String _flagsToSemanticsFlagExpression(dynamic flags) {
     Iterable<SemanticsFlag> list;
     if (flags is int) {
-      list = SemanticsFlag.values
-          .where((SemanticsFlag flag) => (flag.index & flags) != 0);
+      list = SemanticsFlag.values.where((SemanticsFlag flag) => (flag.index & flags) != 0);
     } else {
       list = flags as List<SemanticsFlag>;
     }
@@ -700,8 +650,8 @@ class SemanticsTester {
   static String _actionsToSemanticsActionExpression(dynamic actions) {
     Iterable<SemanticsAction> list;
     if (actions is int) {
-      list = SemanticsAction.values
-          .where((SemanticsAction action) => (action.index & actions) != 0);
+      list =
+          SemanticsAction.values.where((SemanticsAction action) => (action.index & actions) != 0);
     } else {
       list = actions as List<SemanticsAction>;
     }
@@ -710,8 +660,8 @@ class SemanticsTester {
 
   /// Recursively generates [TestSemantics] code for [node] and its children,
   /// indenting the expression by `indentAmount`.
-  static String _generateSemanticsTestForNode(SemanticsNode? node,
-      int indentAmount, DebugSemanticsDumpOrder childOrder) {
+  static String _generateSemanticsTestForNode(
+      SemanticsNode? node, int indentAmount, DebugSemanticsDumpOrder childOrder) {
     if (node == null) {
       return 'null';
     }
@@ -726,13 +676,12 @@ class SemanticsTester {
     if (nodeData.tags != null) {
       buf.writeln('  tags: ${_tagsToSemanticsTagExpression(nodeData.tags!)},');
     }
-    if (nodeData.flags != 0) {
-      buf.writeln(
-          '  flags: ${_flagsToSemanticsFlagExpression(nodeData.flags)},');
+    final int nodeFlagsBitmask = _semFlagsToBitMask(nodeData.flagsCollection);
+    if (nodeFlagsBitmask != 0) {
+      buf.writeln('  flags: ${_flagsToSemanticsFlagExpression(nodeFlagsBitmask)},');
     }
     if (nodeData.actions != 0) {
-      buf.writeln(
-          '  actions: ${_actionsToSemanticsActionExpression(nodeData.actions)},');
+      buf.writeln('  actions: ${_actionsToSemanticsActionExpression(nodeData.actions)},');
     }
     if (node.label.isNotEmpty) {
       // Escape newlines and text directionality control characters.
@@ -759,8 +708,7 @@ class SemanticsTester {
     }
     if (node.hasChildren) {
       buf.writeln('  children: <TestSemantics>[');
-      for (final SemanticsNode child
-          in node.debugListChildrenInOrder(childOrder)) {
+      for (final SemanticsNode child in node.debugListChildrenInOrder(childOrder)) {
         buf
           ..write(_generateSemanticsTestForNode(child, 2, childOrder))
           ..writeln(',');
@@ -769,11 +717,7 @@ class SemanticsTester {
     }
 
     buf.write(')');
-    return buf
-        .toString()
-        .split('\n')
-        .map<String>((String l) => '$indent$l')
-        .join('\n');
+    return buf.toString().split('\n').map<String>((String l) => '$indent$l').join('\n');
   }
 }
 
@@ -793,10 +737,10 @@ class _HasSemantics extends Matcher {
   final DebugSemanticsDumpOrder childOrder;
 
   @override
-  bool matches(
-      covariant SemanticsTester item, Map<dynamic, dynamic> matchState) {
+  bool matches(covariant SemanticsTester item, Map<dynamic, dynamic> matchState) {
+    final SemanticsNode? rootNode = _findRootSemanticsNode(item.tester.binding.rootPipelineOwner);
     final bool doesMatch = _semantics._matches(
-      item.tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode,
+      rootNode,
       matchState,
       ignoreTransform: ignoreTransform,
       ignoreRect: ignoreRect,
@@ -804,10 +748,10 @@ class _HasSemantics extends Matcher {
       childOrder: childOrder,
     );
     if (!doesMatch) {
-      matchState['would-match'] = item
-          .generateTestSemanticsExpressionForCurrentSemanticsTree(childOrder);
+      matchState['would-match'] =
+          item.generateTestSemanticsExpressionForCurrentSemanticsTree(childOrder);
     }
-    if (item.tester.binding.pipelineOwner.semanticsOwner == null) {
+    if (rootNode == null) {
       matchState['additional-notes'] =
           '(Check that the SemanticsTester has not been disposed early.)';
     }
@@ -834,11 +778,10 @@ class _HasSemantics extends Matcher {
     Description result = mismatchDescription
         .add('${matchState[TestSemantics]}\n')
         .add('Current SemanticsNode tree:\n')
-        .add(_indent(RendererBinding.instance.renderView.debugSemantics
+        .add(_indent(RendererBinding.instance.renderViews.firstOrNull?.debugSemantics
             ?.toStringDeep(childOrder: childOrder)))
         .add('\n')
-        .add(
-            'The semantics tree would have matched the following configuration:\n')
+        .add('The semantics tree would have matched the following configuration:\n')
         .add(_indent(matchState['would-match'] as String));
     if (matchState.containsKey('additional-notes')) {
       result = result.add('\n').add(matchState['additional-notes'] as String);
@@ -910,8 +853,7 @@ class _IncludesNodeWith extends Matcher {
   final int? maxValueLength;
 
   @override
-  bool matches(
-      covariant SemanticsTester item, Map<dynamic, dynamic> matchState) {
+  bool matches(covariant SemanticsTester item, Map<dynamic, dynamic> matchState) {
     return item
         .nodesWith(
           attributedLabel: attributedLabel,
@@ -941,8 +883,7 @@ class _IncludesNodeWith extends Matcher {
   @override
   Description describeMismatch(dynamic item, Description mismatchDescription,
       Map<dynamic, dynamic> matchState, bool verbose) {
-    return mismatchDescription
-        .add('could not find node with $_configAsString.\n$_matcherHelp');
+    return mismatchDescription.add('could not find node with $_configAsString.\n$_matcherHelp');
   }
 
   String get _configAsString {
@@ -957,8 +898,7 @@ class _IncludesNodeWith extends Matcher {
       if (scrollPosition != null) 'scrollPosition "$scrollPosition"',
       if (scrollExtentMax != null) 'scrollExtentMax "$scrollExtentMax"',
       if (scrollExtentMin != null) 'scrollExtentMin "$scrollExtentMin"',
-      if (currentValueLength != null)
-        'currentValueLength "$currentValueLength"',
+      if (currentValueLength != null) 'currentValueLength "$currentValueLength"',
       if (maxValueLength != null) 'maxValueLength "$maxValueLength"',
     ];
     return strings.join(', ');
@@ -1003,4 +943,118 @@ Matcher includesNodeWith({
     maxValueLength: maxValueLength,
     currentValueLength: currentValueLength,
   );
+}
+
+/// Finds the first root [SemanticsNode] in the [PipelineOwner] tree by
+/// walking the owner tree rooted at [owner].
+SemanticsNode? _findRootSemanticsNode(PipelineOwner owner) {
+  final SemanticsNode? root = owner.semanticsOwner?.rootSemanticsNode;
+  if (root != null) {
+    return root;
+  }
+  SemanticsNode? found;
+  owner.visitChildren((PipelineOwner child) {
+    found ??= _findRootSemanticsNode(child);
+  });
+  return found;
+}
+
+/// Converts a [SemanticsFlags] object to the integer bitmask equivalent used
+/// for semantic flag comparisons (flags 0–30).
+int _semFlagsToBitMask(SemanticsFlags flags) {
+  var bitmask = 0;
+  if (flags.isChecked != CheckedState.none) {
+    bitmask |= 1 << 0;
+  }
+  if (flags.isChecked == CheckedState.isTrue) {
+    bitmask |= 1 << 1;
+  }
+  if (flags.isSelected == Tristate.isTrue) {
+    bitmask |= 1 << 2;
+  }
+  if (flags.isButton) {
+    bitmask |= 1 << 3;
+  }
+  if (flags.isTextField) {
+    bitmask |= 1 << 4;
+  }
+  if (flags.isFocused == Tristate.isTrue) {
+    bitmask |= 1 << 5;
+  }
+  if (flags.isEnabled != Tristate.none) {
+    bitmask |= 1 << 6;
+  }
+  if (flags.isEnabled == Tristate.isTrue) {
+    bitmask |= 1 << 7;
+  }
+  if (flags.isInMutuallyExclusiveGroup) {
+    bitmask |= 1 << 8;
+  }
+  if (flags.isHeader) {
+    bitmask |= 1 << 9;
+  }
+  if (flags.isObscured) {
+    bitmask |= 1 << 10;
+  }
+  if (flags.scopesRoute) {
+    bitmask |= 1 << 11;
+  }
+  if (flags.namesRoute) {
+    bitmask |= 1 << 12;
+  }
+  if (flags.isHidden) {
+    bitmask |= 1 << 13;
+  }
+  if (flags.isImage) {
+    bitmask |= 1 << 14;
+  }
+  if (flags.isLiveRegion) {
+    bitmask |= 1 << 15;
+  }
+  if (flags.isToggled != Tristate.none) {
+    bitmask |= 1 << 16;
+  }
+  if (flags.isToggled == Tristate.isTrue) {
+    bitmask |= 1 << 17;
+  }
+  if (flags.hasImplicitScrolling) {
+    bitmask |= 1 << 18;
+  }
+  if (flags.isMultiline) {
+    bitmask |= 1 << 19;
+  }
+  if (flags.isReadOnly) {
+    bitmask |= 1 << 20;
+  }
+  if (flags.isFocused != Tristate.none) {
+    bitmask |= 1 << 21;
+  }
+  if (flags.isLink) {
+    bitmask |= 1 << 22;
+  }
+  if (flags.isSlider) {
+    bitmask |= 1 << 23;
+  }
+  if (flags.isKeyboardKey) {
+    bitmask |= 1 << 24;
+  }
+  if (flags.isChecked == CheckedState.mixed) {
+    bitmask |= 1 << 25;
+  }
+  if (flags.isExpanded != Tristate.none) {
+    bitmask |= 1 << 26;
+  }
+  if (flags.isExpanded == Tristate.isTrue) {
+    bitmask |= 1 << 27;
+  }
+  if (flags.isSelected != Tristate.none) {
+    bitmask |= 1 << 28;
+  }
+  if (flags.isRequired != Tristate.none) {
+    bitmask |= 1 << 29;
+  }
+  if (flags.isRequired == Tristate.isTrue) {
+    bitmask |= 1 << 30;
+  }
+  return bitmask;
 }

--- a/test/single_child_two_dimensional_scroll_view_test.dart
+++ b/test/single_child_two_dimensional_scroll_view_test.dart
@@ -20,8 +20,8 @@ class TestScrollPosition extends ScrollPositionWithSingleContext {
 
 class TestScrollController extends ScrollController {
   @override
-  ScrollPosition createScrollPosition(ScrollPhysics physics,
-      ScrollContext context, ScrollPosition? oldPosition) {
+  ScrollPosition createScrollPosition(
+      ScrollPhysics physics, ScrollContext context, ScrollPosition? oldPosition) {
     return TestScrollPosition(
       physics: physics,
       state: context,
@@ -60,11 +60,9 @@ void main() {
 
     // 1st, check that the render object has received the default clip behavior.
     final dynamic renderObject = tester.allRenderObjects
-        .where((RenderObject o) =>
-            o.runtimeType.toString() == '_RenderSingleChild2DViewPort')
+        .where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChild2DViewPort')
         .first;
-    expect(renderObject.clipBehavior,
-        equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
 
     // 2nd, height == window.height test: check that the painting context does not call pushClipRect .
     TestClipPaintingContext context = TestClipPaintingContext();
@@ -112,16 +110,13 @@ void main() {
 
   testWidgets('SingleChildTwoDimensionalScrollView respects clipBehavior',
       (WidgetTester tester) async {
-    await tester.pumpWidget(
-        SingleChildTwoDimensionalScrollView(child: Container(height: 2000.0)));
+    await tester.pumpWidget(SingleChildTwoDimensionalScrollView(child: Container(height: 2000.0)));
 
     // 1st, check that the render object has received the default clip behavior.
     final dynamic renderObject = tester.allRenderObjects
-        .where((RenderObject o) =>
-            o.runtimeType.toString() == '_RenderSingleChild2DViewPort')
+        .where((RenderObject o) => o.runtimeType.toString() == '_RenderSingleChild2DViewPort')
         .first;
-    expect(renderObject.clipBehavior,
-        equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge)); // ignore: avoid_dynamic_calls
 
     // 2nd, check that the painting context has received the default clip behavior.
     final TestClipPaintingContext context = TestClipPaintingContext();
@@ -130,8 +125,7 @@ void main() {
 
     // 3rd, check that the underlying Scrollable(s) have the same clipBehavior
     // Regression test for https://github.com/flutter/flutter/issues/133330
-    Finder scrollable =
-        find.byWidgetPredicate((Widget widget) => widget is Scrollable);
+    Finder scrollable = find.byWidgetPredicate((Widget widget) => widget is Scrollable);
     expect(
       (tester.widgetList(scrollable).first as Scrollable).clipBehavior,
       Clip.hardEdge,
@@ -144,8 +138,7 @@ void main() {
     // 4th, pump a new widget to check that the render object can update its clip behavior.
     await tester.pumpWidget(SingleChildTwoDimensionalScrollView(
         clipBehavior: Clip.antiAlias, child: Container(height: 2000.0)));
-    expect(renderObject.clipBehavior,
-        equals(Clip.antiAlias)); // ignore: avoid_dynamic_calls
+    expect(renderObject.clipBehavior, equals(Clip.antiAlias)); // ignore: avoid_dynamic_calls
 
     // 5th, check that a non-default clip behavior can be sent to the painting context.
     renderObject.paint(context, Offset.zero); // ignore: avoid_dynamic_calls
@@ -153,8 +146,7 @@ void main() {
 
     // 6th, check that the underlying Scrollable has the same clipBehavior
     // Regression test for https://github.com/flutter/flutter/issues/133330
-    scrollable =
-        find.byWidgetPredicate((Widget widget) => widget is Scrollable);
+    scrollable = find.byWidgetPredicate((Widget widget) => widget is Scrollable);
     expect(
       (tester.widgetList(scrollable).first as Scrollable).clipBehavior,
       Clip.antiAlias,
@@ -165,8 +157,7 @@ void main() {
     );
   });
 
-  testWidgets('SingleChildTwoDimensionalScrollView control test',
-      (WidgetTester tester) async {
+  testWidgets('SingleChildTwoDimensionalScrollView control test', (WidgetTester tester) async {
     await tester.pumpWidget(SingleChildTwoDimensionalScrollView(
       child: Container(
         height: 2000.0,
@@ -177,14 +168,12 @@ void main() {
     final RenderBox box = tester.renderObject(find.byType(Container));
     expect(box.localToGlobal(Offset.zero), equals(Offset.zero));
 
-    await tester.drag(find.byType(SingleChildTwoDimensionalScrollView),
-        const Offset(0.0, -200.0));
+    await tester.drag(find.byType(SingleChildTwoDimensionalScrollView), const Offset(0.0, -200.0));
     await tester.pumpAndSettle();
     expect(box.localToGlobal(Offset.zero), equals(const Offset(0.0, -200.0)));
   });
 
-  testWidgets('Changing controllers changes scroll position',
-      (WidgetTester tester) async {
+  testWidgets('Changing controllers changes scroll position', (WidgetTester tester) async {
     final TestScrollController verticalController = TestScrollController();
     final TestScrollController horizontalController = TestScrollController();
     addTearDown(verticalController.dispose);
@@ -212,8 +201,7 @@ void main() {
     expect(scrollable.horizontalScrollable.position, isA<TestScrollPosition>());
   });
 
-  testWidgets('Sets PrimaryScrollController when primary',
-      (WidgetTester tester) async {
+  testWidgets('Sets PrimaryScrollController when primary', (WidgetTester tester) async {
     final ScrollController primaryScrollController = ScrollController();
     addTearDown(primaryScrollController.dispose);
     await tester.pumpWidget(PrimaryScrollController(
@@ -232,8 +220,7 @@ void main() {
     expect(scrollable.verticalDetails.controller, primaryScrollController);
   });
 
-  testWidgets(
-      'Changing scroll controller inside dirty layout builder does not assert',
+  testWidgets('Changing scroll controller inside dirty layout builder does not assert',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
@@ -274,13 +261,11 @@ void main() {
 
   testWidgets('SingleChildTwoDimensionalScrollView are not primary by default',
       (WidgetTester tester) async {
-    const SingleChildTwoDimensionalScrollView view =
-        SingleChildTwoDimensionalScrollView();
+    const SingleChildTwoDimensionalScrollView view = SingleChildTwoDimensionalScrollView();
     expect(view.primary, isNull);
   });
 
-  testWidgets(
-      'SingleChildTwoDimensionalScrollView with controllers are not primary by default',
+  testWidgets('SingleChildTwoDimensionalScrollView with controllers are not primary by default',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
@@ -290,8 +275,7 @@ void main() {
     expect(view.primary, isNull);
   });
 
-  testWidgets(
-      'SingleChildScrollViews use PrimaryScrollController by default on mobile',
+  testWidgets('SingleChildScrollViews use PrimaryScrollController by default on mobile',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
@@ -327,8 +311,7 @@ void main() {
           child: SingleChildTwoDimensionalScrollView(
             primary: true,
             child: Container(
-              constraints:
-                  const BoxConstraints(maxHeight: 200.0, maxWidth: 200.0),
+              constraints: const BoxConstraints(maxHeight: 200.0, maxWidth: 200.0),
               child: ListView(key: innerKey, primary: true),
             ),
           ),
@@ -345,8 +328,7 @@ void main() {
     expect(innerScrollable.controller, isNull);
   });
 
-  testWidgets('SingleChildTwoDimensionalScrollView semantics',
-      (WidgetTester tester) async {
+  testWidgets('SingleChildTwoDimensionalScrollView semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
@@ -369,8 +351,7 @@ void main() {
       ),
     );
 
-    List<TestSemantics> generateSemanticsChildren(
-        {int startHidden = -1, int endHidden = 30}) {
+    List<TestSemantics> generateSemanticsChildren({int startHidden = -1, int endHidden = 30}) {
       final List<TestSemantics> children = <TestSemantics>[];
       for (int index = 0; index < 30; index += 1) {
         final bool isHidden = index <= startHidden || index >= endHidden;
@@ -393,6 +374,7 @@ void main() {
               ],
               actions: <SemanticsAction>[
                 SemanticsAction.scrollUp,
+                SemanticsAction.scrollToOffset,
               ],
               children: <TestSemantics>[
                 TestSemantics(
@@ -423,14 +405,14 @@ void main() {
               actions: <SemanticsAction>[
                 SemanticsAction.scrollUp,
                 SemanticsAction.scrollDown,
+                SemanticsAction.scrollToOffset,
               ],
               children: <TestSemantics>[
                 TestSemantics(
                   flags: <SemanticsFlag>[
                     SemanticsFlag.hasImplicitScrolling,
                   ],
-                  children:
-                      generateSemanticsChildren(startHidden: 14, endHidden: 18),
+                  children: generateSemanticsChildren(startHidden: 14, endHidden: 18),
                 ),
               ],
             ),
@@ -453,6 +435,7 @@ void main() {
               ],
               actions: <SemanticsAction>[
                 SemanticsAction.scrollDown,
+                SemanticsAction.scrollToOffset,
               ],
               children: <TestSemantics>[
                 TestSemantics(
@@ -472,8 +455,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets(
-      'SingleChildTwoDimensionalScrollView semantics clips cover entire child vertical',
+  testWidgets('SingleChildTwoDimensionalScrollView semantics clips cover entire child vertical',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
@@ -490,8 +472,7 @@ void main() {
         ),
       ),
     );
-    final RenderObject scrollRenderObject =
-        tester.renderObject(find.byKey(scrollView));
+    final RenderObject scrollRenderObject = tester.renderObject(find.byKey(scrollView));
     RenderAbstractViewport? viewport;
     void findsRenderViewPort(RenderObject child) {
       if (viewport != null) {
@@ -506,8 +487,7 @@ void main() {
 
     scrollRenderObject.visitChildren(findsRenderViewPort);
     expect(viewport, isNotNull);
-    final RenderObject childRenderObject =
-        tester.renderObject(find.byKey(childBox));
+    final RenderObject childRenderObject = tester.renderObject(find.byKey(childBox));
     Rect semanticsClip = viewport!.describeSemanticsClip(childRenderObject)!;
     expect(semanticsClip.size.height, length);
 
@@ -517,8 +497,7 @@ void main() {
     expect(semanticsClip.size.height, length);
   });
 
-  testWidgets(
-      'SingleChildTwoDimensionalScrollView semantics clips cover entire child',
+  testWidgets('SingleChildTwoDimensionalScrollView semantics clips cover entire child',
       (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     addTearDown(controller.dispose);
@@ -535,8 +514,7 @@ void main() {
         ),
       ),
     );
-    final RenderObject scrollRenderObject =
-        tester.renderObject(find.byKey(scrollView));
+    final RenderObject scrollRenderObject = tester.renderObject(find.byKey(scrollView));
     RenderAbstractViewport? viewport;
     void findsRenderViewPort(RenderObject child) {
       if (viewport != null) {
@@ -551,8 +529,7 @@ void main() {
 
     scrollRenderObject.visitChildren(findsRenderViewPort);
     expect(viewport, isNotNull);
-    final RenderObject childRenderObject =
-        tester.renderObject(find.byKey(childBox));
+    final RenderObject childRenderObject = tester.renderObject(find.byKey(childBox));
     Rect semanticsClip = viewport!.describeSemanticsClip(childRenderObject)!;
     expect(semanticsClip.size.width, length);
 
@@ -565,8 +542,7 @@ void main() {
   testWidgets(
       'SingleChildTwoDimensionalScrollView getOffsetToReveal - will not assert on axis mismatch',
       (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     List<Widget> children;
     await tester.pumpWidget(
@@ -602,8 +578,7 @@ void main() {
 
   testWidgets('SingleChildTwoDimensionalScrollView getOffsetToReveal - down',
       (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     List<Widget> children;
     await tester.pumpWidget(
@@ -642,21 +617,20 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 100.0, 300.0, 100.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed =
+        viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 540.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed =
+        viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 350.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
   });
 
   testWidgets('SingleChildTwoDimensionalScrollView getOffsetToReveal - up',
       (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     final List<Widget> children = List<Widget>.generate(20, (int i) {
       return SizedBox(
@@ -696,21 +670,20 @@ void main() {
     expect(revealed.offset, 400.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 300.0, 100.0));
 
-    revealed = viewport.getOffsetToReveal(target, 0.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed =
+        viewport.getOffsetToReveal(target, 0.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 550.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 190.0, 10.0, 10.0));
 
-    revealed = viewport.getOffsetToReveal(target, 1.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
+    revealed =
+        viewport.getOffsetToReveal(target, 1.0, rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0));
     expect(revealed.offset, 360.0);
     expect(revealed.rect, const Rect.fromLTWH(40.0, 0.0, 10.0, 10.0));
   });
 
   testWidgets('SingleChildTwoDimensionalScrollView getOffsetToReveal - right',
       (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     List<Widget> children;
 
@@ -742,8 +715,7 @@ void main() {
         tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
-    RevealedOffset revealed =
-        viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
     expect(revealed.offset, 500.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
 
@@ -752,22 +724,19 @@ void main() {
     expect(revealed.rect, const Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
 
     revealed = viewport.getOffsetToReveal(target, 0.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0),
-        axis: Axis.horizontal);
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0), axis: Axis.horizontal);
     expect(revealed.offset, 540.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
 
     revealed = viewport.getOffsetToReveal(target, 1.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0),
-        axis: Axis.horizontal);
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0), axis: Axis.horizontal);
     expect(revealed.offset, 350.0);
     expect(revealed.rect, const Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
   });
 
   testWidgets('SingleChildTwoDimensionalScrollView getOffsetToReveal - left',
       (WidgetTester tester) async {
-    final ScrollController controller =
-        ScrollController(initialScrollOffset: 300.0);
+    final ScrollController controller = ScrollController(initialScrollOffset: 300.0);
     addTearDown(controller.dispose);
     final List<Widget> children = List<Widget>.generate(20, (int i) {
       return SizedBox(
@@ -800,8 +769,7 @@ void main() {
         tester.allRenderObjects.whereType<RenderAbstractViewport>().first;
 
     final RenderObject target = tester.renderObject(find.byWidget(children[5]));
-    RevealedOffset revealed =
-        viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
+    RevealedOffset revealed = viewport.getOffsetToReveal(target, 0.0, axis: Axis.horizontal);
     expect(revealed.offset, 500.0);
     expect(revealed.rect, const Rect.fromLTWH(100.0, 0.0, 100.0, 300.0));
 
@@ -810,22 +778,19 @@ void main() {
     expect(revealed.rect, const Rect.fromLTWH(0.0, 0.0, 100.0, 300.0));
 
     revealed = viewport.getOffsetToReveal(target, 0.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0),
-        axis: Axis.horizontal);
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0), axis: Axis.horizontal);
     expect(revealed.offset, 550.0);
     expect(revealed.rect, const Rect.fromLTWH(190.0, 40.0, 10.0, 10.0));
 
     revealed = viewport.getOffsetToReveal(target, 1.0,
-        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0),
-        axis: Axis.horizontal);
+        rect: const Rect.fromLTWH(40.0, 40.0, 10.0, 10.0), axis: Axis.horizontal);
     expect(revealed.offset, 360.0);
     expect(revealed.rect, const Rect.fromLTWH(0.0, 40.0, 10.0, 10.0));
   });
 
   testWidgets('Nested SingleChildTwoDimensionalScrollView showOnScreen',
       (WidgetTester tester) async {
-    final List<List<Widget>> children =
-        List<List<Widget>>.generate(10, (int x) {
+    final List<List<Widget>> children = List<List<Widget>>.generate(10, (int x) {
       return List<Widget>.generate(10, (int y) {
         return SizedBox(
           key: UniqueKey(),
@@ -865,10 +830,8 @@ void main() {
             height: 200.0,
             width: 200.0,
             child: SingleChildTwoDimensionalScrollView(
-              verticalController: controllerY =
-                  ScrollController(initialScrollOffset: 400.0),
-              horizontalController: controllerX =
-                  ScrollController(initialScrollOffset: 400.0),
+              verticalController: controllerY = ScrollController(initialScrollOffset: 400.0),
+              horizontalController: controllerX = ScrollController(initialScrollOffset: 400.0),
               child: Column(
                 children: children.map((List<Widget> widgets) {
                   return Row(
@@ -995,9 +958,7 @@ void main() {
     late List<Widget> children;
 
     Future<void> buildNestedScroller(
-        {required WidgetTester tester,
-        ScrollController? inner,
-        ScrollController? outer}) {
+        {required WidgetTester tester, ScrollController? inner, ScrollController? outer}) {
       return tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -1018,8 +979,7 @@ void main() {
                       child: SingleChildTwoDimensionalScrollView(
                         verticalController: inner,
                         child: Column(
-                          children: children =
-                              List<Widget>.generate(10, (int i) {
+                          children: children = List<Widget>.generate(10, (int i) {
                             return SizedBox(
                               height: 100.0,
                               width: 300.0,
@@ -1041,8 +1001,7 @@ void main() {
       );
     }
 
-    testWidgets('in view in inner, but not in outer',
-        (WidgetTester tester) async {
+    testWidgets('in view in inner, but not in outer', (WidgetTester tester) async {
       final ScrollController inner = ScrollController();
       addTearDown(inner.dispose);
       final ScrollController outer = ScrollController();
@@ -1061,8 +1020,7 @@ void main() {
       expect(outer.offset, 100.0);
     });
 
-    testWidgets('not in view of neither inner nor outer',
-        (WidgetTester tester) async {
+    testWidgets('not in view of neither inner nor outer', (WidgetTester tester) async {
       final ScrollController inner = ScrollController();
       addTearDown(inner.dispose);
       final ScrollController outer = ScrollController();
@@ -1082,11 +1040,9 @@ void main() {
     });
 
     testWidgets('in view in inner and outer', (WidgetTester tester) async {
-      final ScrollController inner =
-          ScrollController(initialScrollOffset: 200.0);
+      final ScrollController inner = ScrollController(initialScrollOffset: 200.0);
       addTearDown(inner.dispose);
-      final ScrollController outer =
-          ScrollController(initialScrollOffset: 200.0);
+      final ScrollController outer = ScrollController(initialScrollOffset: 200.0);
       addTearDown(outer.dispose);
       await buildNestedScroller(
         tester: tester,
@@ -1102,13 +1058,10 @@ void main() {
       expect(inner.offset, 200.0);
     });
 
-    testWidgets('inner shown in outer, but item not visible',
-        (WidgetTester tester) async {
-      final ScrollController inner =
-          ScrollController(initialScrollOffset: 200.0);
+    testWidgets('inner shown in outer, but item not visible', (WidgetTester tester) async {
+      final ScrollController inner = ScrollController(initialScrollOffset: 200.0);
       addTearDown(inner.dispose);
-      final ScrollController outer =
-          ScrollController(initialScrollOffset: 200.0);
+      final ScrollController outer = ScrollController(initialScrollOffset: 200.0);
       addTearDown(outer.dispose);
       await buildNestedScroller(
         tester: tester,
@@ -1128,8 +1081,7 @@ void main() {
         (WidgetTester tester) async {
       final ScrollController inner = ScrollController();
       addTearDown(inner.dispose);
-      final ScrollController outer =
-          ScrollController(initialScrollOffset: 100.0);
+      final ScrollController outer = ScrollController(initialScrollOffset: 100.0);
       addTearDown(outer.dispose);
       await buildNestedScroller(
         tester: tester,
@@ -1147,8 +1099,7 @@ void main() {
   });
 
   testWidgets('keyboardDismissBehavior tests', (WidgetTester tester) async {
-    final List<FocusNode> focusNodes =
-        List<FocusNode>.generate(50, (int i) => FocusNode());
+    final List<FocusNode> focusNodes = List<FocusNode>.generate(50, (int i) => FocusNode());
     addTearDown(() {
       for (final FocusNode node in focusNodes) {
         node.dispose();


### PR DESCRIPTION
## Summary
- Bump SDK constraints: `sdk >=3.6.0`, `flutter >=3.27.0`, `flutter_lints ^5.0.0`
- Update test helpers for current Flutter API (removed deprecated `SemanticsData.elevation/thickness`, `pipelineOwner`, `renderView`, `flags`; added `Ticker.forceFrames`, `SemanticsAction.scrollToOffset`)
- Fix untyped parameters in lib and example format line-length in CI gate

## Test plan
- [x] `scripts/ci/ci_gate.sh --fix` passes (analyze, format, 30/30 tests, 100% coverage, dart doc, example gate)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)