### PR TITLE
feat(scroll): add hitTestBehavior parameter (#4)

### DIFF
--- a/lib/single_child_two_dimensional_scroll_view.dart
+++ b/lib/single_child_two_dimensional_scroll_view.dart
@@ -80,6 +80,7 @@ class SingleChildTwoDimensionalScrollView extends StatelessWidget {
     this.child,
     this.dragStartBehavior = DragStartBehavior.start,
     this.clipBehavior = Clip.hardEdge,
+    this.hitTestBehavior = HitTestBehavior.opaque,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.diagonalDragBehavior = DiagonalDragBehavior.none,
   });
@@ -164,6 +165,9 @@ class SingleChildTwoDimensionalScrollView extends StatelessWidget {
   /// Defaults to [Clip.hardEdge].
   final Clip clipBehavior;
 
+  /// {@macro flutter.widgets.scrollable.hitTestBehavior}
+  final HitTestBehavior hitTestBehavior;
+
   /// {@macro flutter.widgets.scroll_view.keyboardDismissBehavior}
   final ScrollViewKeyboardDismissBehavior keyboardDismissBehavior;
 
@@ -193,6 +197,7 @@ class SingleChildTwoDimensionalScrollView extends StatelessWidget {
       primary: primary,
       keyboardDismissBehavior: keyboardDismissBehavior,
       clipBehavior: clipBehavior,
+      hitTestBehavior: hitTestBehavior,
       diagonalDragBehavior: diagonalDragBehavior,
     );
   }
@@ -206,6 +211,7 @@ class _SingleChild2DScrollView extends TwoDimensionalScrollView {
     super.primary,
     super.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     super.clipBehavior = Clip.hardEdge,
+    super.hitTestBehavior = HitTestBehavior.opaque,
     super.diagonalDragBehavior,
   });
 

--- a/test/single_child_two_dimensional_scroll_view_test.dart
+++ b/test/single_child_two_dimensional_scroll_view_test.dart
@@ -1098,6 +1098,28 @@ void main() {
     });
   });
 
+  testWidgets('SingleChildTwoDimensionalScrollView respects hitTestBehavior',
+      (WidgetTester tester) async {
+    // Default hitTestBehavior is HitTestBehavior.opaque.
+    await tester.pumpWidget(
+      SingleChildTwoDimensionalScrollView(
+        child: Container(height: 2000.0),
+      ),
+    );
+    TwoDimensionalScrollable scrollable = tester.widget(find.byType(TwoDimensionalScrollable));
+    expect(scrollable.hitTestBehavior, HitTestBehavior.opaque);
+
+    // Custom hitTestBehavior is forwarded to TwoDimensionalScrollable.
+    await tester.pumpWidget(
+      SingleChildTwoDimensionalScrollView(
+        hitTestBehavior: HitTestBehavior.translucent,
+        child: Container(height: 2000.0),
+      ),
+    );
+    scrollable = tester.widget(find.byType(TwoDimensionalScrollable));
+    expect(scrollable.hitTestBehavior, HitTestBehavior.translucent);
+  });
+
   testWidgets('keyboardDismissBehavior tests', (WidgetTester tester) async {
     final List<FocusNode> focusNodes = List<FocusNode>.generate(50, (int i) => FocusNode());
     addTearDown(() {


### PR DESCRIPTION
## Summary
- Expose `hitTestBehavior` parameter on `SingleChildTwoDimensionalScrollView`
- Forwards to `TwoDimensionalScrollView` superclass (already supported)
- Defaults to `HitTestBehavior.opaque` to match `SingleChildScrollView`

## Test plan
- [x] Test verifies default is `HitTestBehavior.opaque`
- [x] Test verifies `HitTestBehavior.translucent` is forwarded to `TwoDimensionalScrollable`
- [x] Full CI gate passes (31/31 tests, 100% coverage)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)