### PR TITLE
feat(scroll): add restorationId support (#5)

### DIFF
--- a/lib/single_child_two_dimensional_scroll_view.dart
+++ b/lib/single_child_two_dimensional_scroll_view.dart
@@ -83,6 +83,7 @@ class SingleChildTwoDimensionalScrollView extends StatelessWidget {
     this.hitTestBehavior = HitTestBehavior.opaque,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.diagonalDragBehavior = DiagonalDragBehavior.none,
+    this.restorationId,
   });
 
   /// The amount of space by which to inset the child.
@@ -174,6 +175,9 @@ class SingleChildTwoDimensionalScrollView extends StatelessWidget {
   /// {@macro flutter.widgets.scrollable.diagonalDragBehavior}
   final DiagonalDragBehavior diagonalDragBehavior;
 
+  /// {@macro flutter.widgets.scrollable.restorationId}
+  final String? restorationId;
+
   @override
   Widget build(BuildContext context) {
     Widget contents = child ?? const SizedBox.shrink();
@@ -199,6 +203,7 @@ class SingleChildTwoDimensionalScrollView extends StatelessWidget {
       clipBehavior: clipBehavior,
       hitTestBehavior: hitTestBehavior,
       diagonalDragBehavior: diagonalDragBehavior,
+      restorationId: restorationId,
     );
   }
 }
@@ -213,7 +218,74 @@ class _SingleChild2DScrollView extends TwoDimensionalScrollView {
     super.clipBehavior = Clip.hardEdge,
     super.hitTestBehavior = HitTestBehavior.opaque,
     super.diagonalDragBehavior,
+    this.restorationId,
   });
+
+  /// {@macro flutter.widgets.scrollable.restorationId}
+  final String? restorationId;
+
+  @override
+  Widget build(BuildContext context) {
+    assert(
+      axisDirectionToAxis(verticalDetails.direction) == Axis.vertical,
+    );
+    assert(
+      axisDirectionToAxis(horizontalDetails.direction) == Axis.horizontal,
+    );
+
+    ScrollableDetails mainAxisDetails = switch (mainAxis) {
+      Axis.vertical => verticalDetails,
+      Axis.horizontal => horizontalDetails,
+    };
+
+    final bool effectivePrimary = primary ??
+        mainAxisDetails.controller == null &&
+            PrimaryScrollController.shouldInherit(context, mainAxis);
+
+    if (effectivePrimary) {
+      assert(mainAxisDetails.controller == null);
+      mainAxisDetails = mainAxisDetails.copyWith(controller: PrimaryScrollController.of(context));
+    }
+
+    final scrollable = TwoDimensionalScrollable(
+      horizontalDetails: switch (mainAxis) {
+        Axis.horizontal => mainAxisDetails,
+        Axis.vertical => horizontalDetails,
+      },
+      verticalDetails: switch (mainAxis) {
+        Axis.vertical => mainAxisDetails,
+        Axis.horizontal => verticalDetails,
+      },
+      diagonalDragBehavior: diagonalDragBehavior,
+      viewportBuilder: buildViewport,
+      dragStartBehavior: dragStartBehavior,
+      hitTestBehavior: hitTestBehavior,
+      restorationId: restorationId,
+    );
+
+    final Widget scrollableResult =
+        effectivePrimary ? PrimaryScrollController.none(child: scrollable) : scrollable;
+
+    final ScrollViewKeyboardDismissBehavior effectiveKeyboardDismissBehavior =
+        keyboardDismissBehavior ??
+            ScrollConfiguration.of(context).getKeyboardDismissBehavior(context);
+
+    if (effectiveKeyboardDismissBehavior == ScrollViewKeyboardDismissBehavior.onDrag) {
+      return NotificationListener<ScrollUpdateNotification>(
+        child: scrollableResult,
+        onNotification: (ScrollUpdateNotification notification) {
+          final FocusScopeNode currentScope = FocusScope.of(context);
+          if (notification.dragDetails != null &&
+              !currentScope.hasPrimaryFocus &&
+              currentScope.hasFocus) {
+            FocusManager.instance.primaryFocus?.unfocus();
+          }
+          return false;
+        },
+      );
+    }
+    return scrollableResult;
+  }
 
   @override
   Widget buildViewport(

--- a/test/single_child_two_dimensional_scroll_view_test.dart
+++ b/test/single_child_two_dimensional_scroll_view_test.dart
@@ -1098,6 +1098,24 @@ void main() {
     });
   });
 
+  testWidgets(
+      'SingleChildTwoDimensionalScrollView forwards restorationId to TwoDimensionalScrollable',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SingleChildTwoDimensionalScrollView(
+          restorationId: 'test_restoration',
+          child: Container(height: 2000.0),
+        ),
+      ),
+    );
+
+    final TwoDimensionalScrollable scrollable =
+        tester.widget<TwoDimensionalScrollable>(find.byType(TwoDimensionalScrollable));
+    expect(scrollable.restorationId, 'test_restoration');
+  });
+
   testWidgets('SingleChildTwoDimensionalScrollView respects hitTestBehavior',
       (WidgetTester tester) async {
     // Default hitTestBehavior is HitTestBehavior.opaque.


### PR DESCRIPTION
## Summary
- Expose `restorationId` parameter on `SingleChildTwoDimensionalScrollView`
- Passes through to `TwoDimensionalScrollable` which handles restoration scoping for both axes
- Override `build()` in `_SingleChild2DScrollView` to thread the parameter (superclass lacks it)

## Test plan
- [x] Test verifies `restorationId` is forwarded to `TwoDimensionalScrollable`
- [x] Full CI gate passes (32/32 tests, 98% coverage)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)